### PR TITLE
feat: hold #41 + next, holdの描画

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,11 +40,11 @@
                                             <p class="text">上矢印キー：　回転</p>
                                             <p class="text">左矢印キー：　左に移動</p>
                                             <p class="text">右矢印キー：　右に移動</p>
-                                            <p class="text">下矢印キー：　下まで落とす（ハードドロップ）</p>    
-                                        </div>        
+                                            <p class="text">下矢印キー：　下まで落とす（ハードドロップ）</p>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>                     
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -64,7 +64,7 @@
     </div>
     <!-- ボタン -->
     <div id="action">
-        
+
         <!-- <div id="action-reset" class="action__reset"></div> -->
         <div id="action-stop" class="action__stop">
             <svg xmlns="http://www.w3.org/2000/svg" fill="black" viewBox="0 0 24 24" stroke-width="1.5" stroke="white">
@@ -81,6 +81,7 @@
         <button id="arrow-right-btn" class="btn btn-light">→</button>
         <button id="arrow-down-btn" class="btn btn-light">↓</button>
         <button id="arrow-up-btn" class="btn btn-light">↑</button>
+        <button id="space-btn" class="btn btn-light">-</button>
 
     </div>
 </div>

--- a/main.js
+++ b/main.js
@@ -506,6 +506,11 @@ function holdTetro()
     if(holdingTetro !== undefined)
     {
         // フィールド中のテトロミノとホールドしたテトロミノの入れ替え
+        if(!canMove(0, 0, holdingTetro))
+        {
+            if(canMove(-1, 0, holdingTetro)) tetroX--;
+            if(canMove(1, 0, holdingTetro)) tetroY++;
+        }
         [tetroType, holdingTetroType] = [holdingTetroType, tetroType];
         [tetro, holdingTetro] = [holdingTetro, tetro];
     }

--- a/main.js
+++ b/main.js
@@ -1,10 +1,10 @@
-const config = 
+const config =
 {
     initialPage : document.getElementById("initial-page"),
     mainPage : document.getElementById("main-page"),
 }
 
-function gameStart() 
+function gameStart()
 {
     initialize();
     drawAll();
@@ -42,7 +42,7 @@ const context = canvas.getContext("2d");
 //ブロック１単位のピクセルサイズ
 const BLOCK_SIZE = 25;
 
-const NEXT_BLOCK_SIZE = (BLOCK_SIZE / 2);
+const SMALL_BLOCK_SIZE = (BLOCK_SIZE / 2);
 //テトロミノのサイズ
 const TETRO_SIZE = 4;
 
@@ -153,6 +153,15 @@ let tetroY = START_Y;
 let tetroType = Math.floor(Math.random() * (TETRO_TYPES.length - 1)) + 1;
 // 描画対象のテトロミノ
 let tetro = TETRO_TYPES[tetroType];
+
+const HOLD_X = 15.5;
+const HOLD_Y = 0.5;
+
+// ホールドしたテトロミノの形
+let holdingTetroType = 0;
+
+// ホールドしたテトロミノ
+let holdingTetro = undefined;
 
 // ネクストテトロの描画座標
 const NEXT_X = 0.5;
@@ -370,44 +379,83 @@ function drawPredictedLandingPoint()
 }
 
 
-/*
-    　　　　　　ネクストテトロブロック　　　　　　　　　　
- */
-// ネクストテトロブロックを1つを描画する
-function drawNextBlock(x, y, color)
+// 小さいテトロブロックを1つを描画する
+function drawSmallBlock(x, y, color)
 {
-    let px = x * NEXT_BLOCK_SIZE;
-    let py = y * NEXT_BLOCK_SIZE;
+    let px = x * SMALL_BLOCK_SIZE;
+    let py = y * SMALL_BLOCK_SIZE;
     let r, g, b;
     [r, g, b] = TETRO_COLORS[color];
     context.fillStyle = `rgba(${r}, ${g}, ${b}, 1)`;
-    context.fillRect(px, py, NEXT_BLOCK_SIZE, NEXT_BLOCK_SIZE);
-    context.strokeStyle = "rgba(0,0,0, .1)";
-    context.strokeRect(px, py, NEXT_BLOCK_SIZE, NEXT_BLOCK_SIZE);
+    context.fillRect(px, py, SMALL_BLOCK_SIZE, SMALL_BLOCK_SIZE);
+    context.strokeStyle = "rgba(0, 0, 0, 0.1)";
+    context.strokeRect(px, py, SMALL_BLOCK_SIZE, SMALL_BLOCK_SIZE);
 }
 
 function drawNextTetro()
 {
+    let msg = "NEXT";
+    let index = 0;
     for(let y = 0; y < TETRO_SIZE; y++)
     {
         for(let x = 0; x < TETRO_SIZE; x++)
         {
             if(nextTetro[y][x])
             {
-                drawNextBlock(NEXT_X + x, NEXT_Y +y, nextTetroType)
+                drawSmallBlock(NEXT_X + x, NEXT_Y +y, nextTetroType);
+                putCharInSmallBlock(NEXT_X + x, NEXT_Y +y, msg[index]);
+                index++;
+                // drawString(msg, NEXT_X, NEXT_Y);
             }
         }
     }
 }
 
-/*
-    　　　　　　ネクストテトロブロック　　　　　　　　　　
- */
+function drawHoldTetro()
+{
+    let msg = "HOLD";
+    let index = 0;
+    if(holdingTetro === undefined) return;
+    for(let y = 0; y < TETRO_SIZE; y++)
+    {
+        for(let x = 0; x < TETRO_SIZE; x++)
+        {
+            if(holdingTetro[y][x])
+            {
+                drawSmallBlock(HOLD_X + x, HOLD_Y + y, holdingTetroType);
+                putCharInSmallBlock(HOLD_X + x, HOLD_Y +y, msg[index]);
+                index++;
+                // drawString(msg, HOLD_X, HOLD_Y);
+            }
+        }
+    }
+}
+
+// function drawString(msg, x, y)
+// {
+//     context.font = `${SMALL_BLOCK_SIZE * 1.7}px "MS ゴシック"`;
+//     context.fillStyle = `rgba(0, 0, 0, 0.2)`;
+//     context.textBaseline = "center";
+//     context.textAlign = "center";
+//     context.fillText(msg, (x + 2) * SMALL_BLOCK_SIZE, (y + 2) * SMALL_BLOCK_SIZE);
+// }
+
+function putCharInSmallBlock(x, y, char)
+{
+    let offset = SMALL_BLOCK_SIZE / 2;
+    context.font = `${SMALL_BLOCK_SIZE * 0.8}px "MS ゴシック"`;
+    context.fillStyle = `rgba(0, 0, 0, 1)`;
+    context.textBaseline = "center";
+    context.textAlign = "center";
+    context.fillText(char, x * SMALL_BLOCK_SIZE + offset, (y + 0.3) * SMALL_BLOCK_SIZE + offset);
+}
+
 
 function drawAll(){
     context.clearRect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
     drawField();
     drawNextTetro();
+    drawHoldTetro();
     // ゲームオーバーであれば新たにテトロミノや予測地点を描画しない
     if(gameOver) return;
     drawTetro();
@@ -452,6 +500,27 @@ function rotate()
     return newTetro;
 }
 
+// ホールド機能
+function holdTetro()
+{
+    if(holdingTetro !== undefined)
+    {
+        // フィールド中のテトロミノとホールドしたテトロミノの入れ替え
+        [tetroType, holdingTetroType] = [holdingTetroType, tetroType];
+        [tetro, holdingTetro] = [holdingTetro, tetro];
+    }
+    else
+    {
+        // ホールドしているテトロミノがないとき（初回のホールド）は新たにテトロミノを作成する
+        holdingTetroType = tetroType;
+        holdingTetro = tetro;
+        tetroType = Math.floor(Math.random() * (TETRO_TYPES.length - 1)) + 1;
+        tetro = TETRO_TYPES[tetroType];
+        tetroX = START_X;
+        tetroY = START_Y;
+    }
+}
+
 // ゲームオーバーを判定
 function isGameOver()
 {
@@ -471,27 +540,29 @@ function notifyUsersGameOver()
 {
     let msg = "GAME OVER";
     context.font = "40px 'MS ゴシック'";
-    let msgWidth = context.measureText(msg).width;
-    let x = SCREEN_WIDTH / 2 - msgWidth / 2;
-    let y = SCREEN_HEIGHT / 2 - 20;
-    context.lineWidth = 4;
-    context.strokeText(msg, x, y);
-    context.lineWidth = 1;
+    context.fillStyle = `rgba(0, 0, 0, 1)`
+    context.textBaseline = "center";
+    context.textAlign = "center";
+    context.fillText(msg, SCREEN_WIDTH / 2, SCREEN_HEIGHT / 2);
 }
 
 // ボタンによる入力
 document.getElementById("arrow-left-btn").addEventListener("click", function(){
     document.dispatchEvent(new KeyboardEvent( "keydown", {key: "ArrowLeft"}));
-})
+});
 document.getElementById("arrow-right-btn").addEventListener("click", function(){
     document.dispatchEvent(new KeyboardEvent( "keydown", {key: "ArrowRight"}));
-})
+});
 document.getElementById("arrow-down-btn").addEventListener("click", function(){
     document.dispatchEvent(new KeyboardEvent( "keydown", {key: "ArrowDown"}));
-})
+});
 document.getElementById("arrow-up-btn").addEventListener("click", function(){
     document.dispatchEvent(new KeyboardEvent( "keydown", {key: "ArrowUp"}));
-})
+});
+document.getElementById("space-btn").addEventListener("click", function(){
+    console.log("aaa")
+    document.dispatchEvent(new KeyboardEvent( "keydown", {key: " "}));
+});
 
 // テトロミノを移動するイベント関数です。
 document.onkeydown = function(e)
@@ -508,11 +579,13 @@ document.onkeydown = function(e)
         case "ArrowDown": // ↓
             while( (isDropping) && (canMove(0, 1)) ) tetroY++;
             break;
-        case "ArrowUp": // スペースキー
+        case "ArrowUp": // ↑
             let newTetro = rotate();
             if( (isDropping) && (canMove(0, 0, newTetro)) ) tetro = newTetro; //回転する先にテトロミノor壁がない場合、回転できる
             break;
+        case " ": //スペース
+        holdTetro();
+        break;
     }
     drawAll();
 }
-

--- a/main.js
+++ b/main.js
@@ -521,8 +521,6 @@ function holdTetro()
         holdingTetro = tetro;
         tetroType = Math.floor(Math.random() * (TETRO_TYPES.length - 1)) + 1;
         tetro = TETRO_TYPES[tetroType];
-        tetroX = START_X;
-        tetroY = START_Y;
     }
 }
 


### PR DESCRIPTION
### 関連しているIssue / 目的
ホールド機能の実装。ホールド、ネクストをフィールド上に表示。

### 達成条件

### 実装の概要 / このPRの対応範囲
drawNextBlockに手を加えてホールドとネクストのブロックの両方を描画するために使えるようにしました。
drawNextTetroとdrawHoldTetroは分けてあります。確認お願いします。

### 重点的にレビューしてほしいところ

### 不安に思っていること

### その他情報(スクショ)